### PR TITLE
Configuration: Track whether the object holds root config values or not

### DIFF
--- a/src/Lunr/Core/Configuration.php
+++ b/src/Lunr/Core/Configuration.php
@@ -50,12 +50,22 @@ class Configuration implements ArrayAccess, Iterator, Countable
     private bool $size_invalid;
 
     /**
+     * Whether the object holds top-level config values or not
+     *
+     * @var bool
+     *
+     * @phpstan-ignore property.onlyWritten
+     */
+    private readonly bool $isRootConfig;
+
+    /**
      * Constructor.
      *
-     * @param array<int|string,mixed>|bool $bootstrap Bootstrap config values, aka config values used before
-     *                                                the class has been instantiated.
+     * @param array<int|string,mixed>|bool $bootstrap    Bootstrap config values, aka config values used before
+     *                                                   the class has been instantiated.
+     * @param bool                         $isRootConfig Whether the object holds top-level config values or not
      */
-    public function __construct(array|bool $bootstrap = FALSE)
+    public function __construct(array|bool $bootstrap = FALSE, bool $isRootConfig = TRUE)
     {
         if (!is_array($bootstrap))
         {
@@ -70,6 +80,7 @@ class Configuration implements ArrayAccess, Iterator, Countable
         $this->config = $bootstrap;
         $this->rewind();
         $this->size_invalid = TRUE;
+        $this->isRootConfig = $isRootConfig;
         $this->count();
     }
 
@@ -167,7 +178,7 @@ class Configuration implements ArrayAccess, Iterator, Countable
         {
             if (is_array($value))
             {
-                $array[$key] = new self($value);
+                $array[$key] = new self($value, isRootConfig: FALSE);
             }
         }
 

--- a/src/Lunr/Core/Tests/ConfigurationArrayConstructorTest.php
+++ b/src/Lunr/Core/Tests/ConfigurationArrayConstructorTest.php
@@ -53,6 +53,14 @@ class ConfigurationArrayConstructorTest extends ConfigurationTest
     }
 
     /**
+     * Test that the class was initialized as a root config container.
+     */
+    public function testObjectIsRootConfig(): void
+    {
+        $this->assertPropertySame('isRootConfig', TRUE);
+    }
+
+    /**
      * Test that $config is set up according to the input.
      */
     public function testConfig(): void
@@ -61,6 +69,9 @@ class ConfigurationArrayConstructorTest extends ConfigurationTest
 
         $this->assertEquals($this->config['test1'], $output['test1']);
         $this->assertInstanceOf('Lunr\Core\Configuration', $output['test2']);
+
+        $property = $this->get_reflection_property('isRootConfig');
+        $this->assertFalse($property->getValue($output['test2']));
     }
 
     /**

--- a/src/Lunr/Core/Tests/ConfigurationBaseTest.php
+++ b/src/Lunr/Core/Tests/ConfigurationBaseTest.php
@@ -60,6 +60,14 @@ class ConfigurationBaseTest extends ConfigurationTest
     }
 
     /**
+     * Test that the class was initialized as a root config container.
+     */
+    public function testObjectIsRootConfig(): void
+    {
+        $this->assertPropertySame('isRootConfig', TRUE);
+    }
+
+    /**
      * Test the function __toString().
      *
      * @covers Lunr\Core\Configuration::__toString

--- a/src/Lunr/Core/Tests/ConfigurationConvertArrayToClassTest.php
+++ b/src/Lunr/Core/Tests/ConfigurationConvertArrayToClassTest.php
@@ -78,6 +78,9 @@ class ConfigurationConvertArrayToClassTest extends ConfigurationTest
 
         $this->assertInstanceOf('Lunr\Core\Configuration', $output['test2']);
 
+        $property = $this->get_reflection_property('isRootConfig');
+        $this->assertFalse($property->getValue($output['test2']));
+
         $property = $this->get_reflection_property('size');
         $this->assertEquals(2, $property->getValue($output['test2']));
 


### PR DESCRIPTION
This is the first step towards config file autoloading. In order to load a config file based on the top-level config key, we need to know whether it is a top-level config key or not.