### PR TITLE
Configuration: Differentiate array to class transformation

### DIFF
--- a/src/Lunr/Core/Configuration.php
+++ b/src/Lunr/Core/Configuration.php
@@ -78,7 +78,7 @@ class Configuration implements ArrayAccess, Iterator, Countable
 
         if (!empty($bootstrap))
         {
-            $bootstrap = $this->convertArrayToClass($bootstrap);
+            $bootstrap = $this->convertArrayToClassArray($bootstrap);
         }
 
         $this->config = $bootstrap;
@@ -248,7 +248,7 @@ class Configuration implements ArrayAccess, Iterator, Countable
         $config = array_replace_recursive($this->toArray(), $envConfig);
         if ($config !== [])
         {
-            $config = $this->convertArrayToClass($config);
+            $config = $this->convertArrayToClassArray($config);
         }
 
         $this->config      = $config;
@@ -262,7 +262,7 @@ class Configuration implements ArrayAccess, Iterator, Countable
      *
      * @return array<int|string,mixed> An array with sub-arrays converted
      */
-    private function convertArrayToClass(array $array): array
+    private function convertArrayToClassArray(array $array): array
     {
         if (empty($array))
         {
@@ -283,6 +283,23 @@ class Configuration implements ArrayAccess, Iterator, Countable
     }
 
     /**
+     * Convert an input array recursively into a Configuration class hierarchy.
+     *
+     * @param array<int|string,mixed> $array Input array
+     *
+     * @return self The array value transformed to a Configuration class instance
+     */
+    private function convertArrayToClass(array $array): self
+    {
+        if (empty($array))
+        {
+            return new self(isRootConfig: FALSE);
+        }
+
+        return new self($array, isRootConfig: FALSE);
+    }
+
+    /**
      * Offset to set.
      *
      * Assigns a value to the specified offset.
@@ -297,14 +314,7 @@ class Configuration implements ArrayAccess, Iterator, Countable
     {
         if (is_array($value))
         {
-            if ($value === [])
-            {
-                $value = new self(isRootConfig: FALSE);
-            }
-            else
-            {
-                $value = $this->convertArrayToClass($value);
-            }
+            $value = $this->convertArrayToClass($value);
         }
 
         if (is_null($offset))

--- a/src/Lunr/Core/Tests/ConfigurationConvertArrayToClassArrayTest.php
+++ b/src/Lunr/Core/Tests/ConfigurationConvertArrayToClassArrayTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * This file contains the ConfigurationConvertArrayToClassTest
+ * This file contains the ConfigurationConvertArrayToClassArrayTest
  * class.
  *
  * SPDX-FileCopyrightText: Copyright 2011 M2mobi B.V., Amsterdam, The Netherlands
@@ -14,11 +14,11 @@ namespace Lunr\Core\Tests;
 use Lunr\Core\Configuration;
 
 /**
- * Test for the method convertArrayToClass().
+ * Test for the method convertArrayToClassArray().
  *
  * @covers Lunr\Core\Configuration
  */
-class ConfigurationConvertArrayToClassTest extends ConfigurationTestCase
+class ConfigurationConvertArrayToClassArrayTest extends ConfigurationTestCase
 {
 
     /**
@@ -30,23 +30,22 @@ class ConfigurationConvertArrayToClassTest extends ConfigurationTestCase
     }
 
     /**
-     * Test convertArrayToClass() with an empty array as input.
+     * Test convertArrayToClassArray() with an empty array as input.
      *
-     * @covers Lunr\Core\Configuration::convertArrayToClass
+     * @covers Lunr\Core\Configuration::convertArrayToClassArray
      */
     public function testConvertArrayToClassWithEmptyArrayValue(): void
     {
-        $method = $this->getReflectionMethod('convertArrayToClass');
+        $method = $this->getReflectionMethod('convertArrayToClassArray');
         $output = $method->invokeArgs($this->class, [ [] ]);
 
-        $this->assertInstanceOf(Configuration::class, $output);
-        $this->assertArrayEmpty($output->toArray());
+        $this->assertArrayEmpty($output);
     }
 
     /**
-     * Test convertArrayToClass() with an array as input.
+     * Test convertArrayToClassArray() with an array as input.
      *
-     * @covers Lunr\Core\Configuration::convertArrayToClass
+     * @covers Lunr\Core\Configuration::convertArrayToClassArray
      */
     public function testConvertArrayToClassWithArrayValue(): void
     {
@@ -54,18 +53,17 @@ class ConfigurationConvertArrayToClassTest extends ConfigurationTestCase
         $input['test']  = 'String';
         $input['test1'] = 1;
 
-        $method = $this->getReflectionMethod('convertArrayToClass');
+        $method = $this->getReflectionMethod('convertArrayToClassArray');
         $output = $method->invokeArgs($this->class, [ $input ]);
 
-        $this->assertInstanceOf(Configuration::class, $output);
-        $this->assertEquals($input, $output->toArray());
+        $this->assertEquals($input, $output);
     }
 
     /**
-     * Test convertArrayToClass() with a multi-dimensional array as input.
+     * Test convertArrayToClassArray() with a multi-dimensional array as input.
      *
      * @depends testConvertArrayToClassWithArrayValue
-     * @covers  Lunr\Core\Configuration::convertArrayToClass
+     * @covers  Lunr\Core\Configuration::convertArrayToClassArray
      */
     public function testConvertArrayToClassWithMultidimensionalArrayValue(): void
     {
@@ -75,10 +73,10 @@ class ConfigurationConvertArrayToClassTest extends ConfigurationTestCase
         $config['test2']['test3'] = 1;
         $config['test2']['test4'] = FALSE;
 
-        $method = $this->getReflectionMethod('convertArrayToClass');
+        $method = $this->getReflectionMethod('convertArrayToClassArray');
         $output = $method->invokeArgs($this->class, [ $config ]);
 
-        $this->assertInstanceOf(Configuration::class, $output);
+        $this->assertTrue(is_array($output));
 
         $this->assertInstanceOf(Configuration::class, $output['test2']);
 


### PR DESCRIPTION
Rename the existing mechanism to convertArrayToClassArray(), to be used when bootstrapping config values (so the root value stays an array that can be assigned to the config property).

Reimplement convertArrayToClass() to always convert to a class instance, used when setting an arrat value with offsetSet().