### PR TITLE
Configuration: Match offsetExists() behavior with array_key_exists()

### DIFF
--- a/src/Lunr/Core/Configuration.php
+++ b/src/Lunr/Core/Configuration.php
@@ -398,7 +398,7 @@ class Configuration implements ArrayAccess, Iterator, Countable
 
         $this->autoloadFile($offset);
 
-        return isset($this->config[$offset]);
+        return array_key_exists($offset, $this->config);
     }
 
     /**


### PR DESCRIPTION
array_key_exists() allows more types than just string or int, so offsetExists should too.